### PR TITLE
(feat): ramp up time should be excluded from qps

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -285,6 +285,10 @@ var rootCmd = &cobra.Command{
 			Report: result,
 		}
 
+		// Correct Total Time & RPS calculations to exclude ramp up time
+		result.Total = result.Total - rampDuration
+		result.Rps = float64(result.Count) / result.Total.Seconds()
+
 		err = p.Print("summary")
 		if err != nil {
 			fmt.Printf("Failed to print report with error: %s\n", err)


### PR DESCRIPTION
GHZ qps and total time does not exclude ramp up time:
- https://github.com/bojand/ghz/blob/master/runner/reporter.go#L257C1-L257C52
