### PR TITLE
add json output file flag

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -9,7 +9,14 @@ import (
 	"strings"
 )
 
-func PrintReport(outputFilename string, result *runner.Report, includeRequestMetadata bool) {
+type ReportType string
+
+var (
+	ReportTypeHTML ReportType = "html"
+	ReportTypeJSON ReportType = "json"
+)
+
+func PrintReport(outputFilename string, result *runner.Report, includeRequestMetadata bool, reportType ReportType) {
 	fmt.Println("\nPrinting Report...")
 	processReport(result)
 	p := printer.ReportPrinter{
@@ -24,7 +31,7 @@ func PrintReport(outputFilename string, result *runner.Report, includeRequestMet
 	}
 
 	cd := CurDir()
-	reportFile := filepath.Join(cd, fmt.Sprintf("%s.html", strings.TrimSuffix(outputFilename, ".html")))
+	reportFile := filepath.Join(cd, fmt.Sprintf("%s.%s", strings.TrimSuffix(outputFilename, "."+string(reportType)), reportType))
 	outputFile, err := os.OpenFile(reportFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
 	if err != nil {
 		fmt.Printf("Failed to open report file with error: %s\n", err)
@@ -41,7 +48,7 @@ func PrintReport(outputFilename string, result *runner.Report, includeRequestMet
 		Report: result,
 	}
 
-	err = htmlSaver.Print("html")
+	err = htmlSaver.Print(string(reportType))
 	if err != nil {
 		fmt.Printf("Failed to save report with error: %s\n", err)
 		os.Exit(1)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -16,7 +16,7 @@ var (
 	ReportTypeJSON ReportType = "json"
 )
 
-func PrintReport(outputFilename string, result *runner.Report, includeRequestMetadata bool, reportType ReportType) {
+func PrintReport(result *runner.Report) {
 	fmt.Println("\nPrinting Report...")
 	processReport(result)
 	p := printer.ReportPrinter{
@@ -29,9 +29,14 @@ func PrintReport(outputFilename string, result *runner.Report, includeRequestMet
 		fmt.Printf("Failed to print report with error: %s\n", err)
 		os.Exit(1)
 	}
+}
 
-	cd := CurDir()
-	reportFile := filepath.Join(cd, fmt.Sprintf("%s.%s", strings.TrimSuffix(outputFilename, "."+string(reportType)), reportType))
+func SaveReport(outputFilename string, result *runner.Report, includeRequestMetadata bool, reportType ReportType) {
+	filenameNoPrefix := strings.TrimSuffix(outputFilename, "."+string(reportType))
+	reportFile := filepath.Join(
+		CurDir(),
+		fmt.Sprintf("%s.%s", filenameNoPrefix, reportType),
+	)
 	outputFile, err := os.OpenFile(reportFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
 	if err != nil {
 		fmt.Printf("Failed to open report file with error: %s\n", err)
@@ -43,12 +48,12 @@ func PrintReport(outputFilename string, result *runner.Report, includeRequestMet
 		result.Options.Metadata = nil
 	}
 
-	htmlSaver := printer.ReportPrinter{
+	fileSaver := printer.ReportPrinter{
 		Out:    outputFile,
 		Report: result,
 	}
 
-	err = htmlSaver.Print(string(reportType))
+	err = fileSaver.Print(string(reportType))
 	if err != nil {
 		fmt.Printf("Failed to save report with error: %s\n", err)
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -259,7 +259,7 @@ func init() {
 	flags.UintVar(&concurrency, "concurrency", 16, "Number of workers (concurrency) for requests.")
 	flags.DurationVar(&timeout, "timeout", 20*time.Second, "Timeout for requests.")
 	flags.StringVar(&outputFile, "output_file", "result.html", "Output filename for the saved report.")
-	flags.StringVar(&jsonOutputFile, "json_output_file", "result.json", "If specified, save the report as an additional file in JSON format.")
+	flags.StringVar(&jsonOutputFile, "json_output_file", "", "If specified, save the report as an additional file in JSON format.")
 	flags.StringVar(&token, "token", os.Getenv("CHALK_BENCHMARK_TOKEN"), "jwt to use for the request—if this is provided the client_id and client_secret will be ignored.")
 	flags.StringVar(&scheduleFile, "schedule_file", "", "Provide the schedule for the benchmark query as a JSON file.")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -171,10 +171,10 @@ var rootCmd = &cobra.Command{
 
 		result = RunBenchmarks(benchmarkRunner)
 
-		PrintReport(outputFile, result, includeRequestMetadata, ReportTypeHTML)
-
+		PrintReport(result)
+		SaveReport(outputFile, result, includeRequestMetadata, ReportTypeHTML)
 		if jsonOutputFile != "" {
-			PrintReport(jsonOutputFile, result, includeRequestMetadata, ReportTypeJSON)
+			SaveReport(jsonOutputFile, result, includeRequestMetadata, ReportTypeJSON)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -171,7 +171,11 @@ var rootCmd = &cobra.Command{
 
 		result = RunBenchmarks(benchmarkRunner)
 
-		PrintReport(outputFile, result, includeRequestMetadata)
+		PrintReport(outputFile, result, includeRequestMetadata, ReportTypeHTML)
+
+		if jsonOutputFile != "" {
+			PrintReport(jsonOutputFile, result, includeRequestMetadata, ReportTypeJSON)
+		}
 	},
 }
 
@@ -203,6 +207,7 @@ var numConnections uint
 var concurrency uint
 var timeout time.Duration
 var outputFile string
+var jsonOutputFile string
 var scheduleFile string
 
 // environment & client parameters
@@ -254,6 +259,7 @@ func init() {
 	flags.UintVar(&concurrency, "concurrency", 16, "Number of workers (concurrency) for requests.")
 	flags.DurationVar(&timeout, "timeout", 20*time.Second, "Timeout for requests.")
 	flags.StringVar(&outputFile, "output_file", "result.html", "Output filename for the saved report.")
+	flags.StringVar(&jsonOutputFile, "json_output_file", "result.json", "If specified, save the report as an additional file in JSON format.")
 	flags.StringVar(&token, "token", os.Getenv("CHALK_BENCHMARK_TOKEN"), "jwt to use for the request—if this is provided the client_id and client_secret will be ignored.")
 	flags.StringVar(&scheduleFile, "schedule_file", "", "Provide the schedule for the benchmark query as a JSON file.")
 


### PR DESCRIPTION
Adds a `--json_output_file` flag that when specified will output an additional report in json. Useful for running a benchmark and parsing the results by script. 