### PR TITLE
adding chained role to have GetAuthorizationToken access

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -17,6 +17,7 @@ jobs:
       AWS_ACCOUNT_ID: 754784422779
       AWS_REGION: us-east-1
       AWS_GHA_ARN: arn:aws:iam::754784422779:role/chalk-private-github-actions
+      AWS_API_SERVER_ARN: arn:aws:iam::754784422779:role/chalk-api-server
 
     steps:
       - name: Checkout repository
@@ -44,6 +45,14 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_GHA_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+
+      # Need to role chain to role that has GetAuthorizationToken
+      - name: Assume chained role for ECR access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_API_SERVER_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-chaining: true
 
       - name: Login to Amazon ECR
         run: |


### PR DESCRIPTION
Currently getting this error:
```
An error occurred (AccessDeniedException) when calling the GetAuthorizationToken operation: User: arn:aws:sts::754784422779:assumed-role/chalk-private-github-actions/GitHubActions is not authorized to perform: ecr:GetAuthorizationToken on resource: * because no identity-based policy allows the ecr:GetAuthorizationToken action
```

Was recommended to use role chaining with a role with the appropriate access rather than adding access to existing role or creating a new role