### PR TITLE
p99_9 flag update.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,7 @@ var rootCmd = &cobra.Command{
 			runner.WithConcurrency(concurrency),
 			runner.WithInsecure(insecureQueryHost),
 			runner.WithSkipTLSVerify(skipTLS),
+			runner.WithP99_9(p99_9),
 		}
 		slog.Debug(fmt.Sprintf("numConnections: %s, timeout: %s, concurrency: %s, insecure: %b, skipTLSVerify: %b", numConnections, timeout, concurrency, insecureQueryHost, skipTLS))
 
@@ -339,7 +340,8 @@ func init() {
 	flags.BoolVar(&p50, "p50", false, "The amount of time to use in bucketing P50—the default is to not include P50 in the chart")
 	flags.BoolVar(&p95, "p95", false, "The amount of time to use in bucketing P95—the default is to not include P95 in the chart")
 	flags.BoolVar(&p99, "p99", false, "The amount of time to use in bucketing P99—the default is to not include P99 in the chart")
-	flags.BoolVar(&p99_9, "p99_9", false, "The amount of time to use in bucketing P99.9—the default is to not include P99.9 in the chart")
+	// Due to the nature of using such a high percentile with rounding/truncating + time measurements, it's recommended to use this with benchmarks > 1k queries total, ideally > 10k.
+	flags.BoolVar(&p99_9, "p99_9", false, "Determines whether or not to calculate p99.9 in the results. Also the amount of time to use in bucketing P99.9—the default is to not include P99.9 in the chart")
 	flags.DurationVar(&percentileWindow, "percentile-window", time.Duration(5.0*float64(time.Second)), "The amount of time to use in bucketing P99—the default is to not include P99 in the chart")
 
 	// trace sampling

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.23.0
 require (
 	github.com/apache/arrow/go/v17 v17.0.0
 	github.com/chalk-ai/chalk-go v0.17.1
-	github.com/chalk-ai/ghz v0.1.22
+	github.com/chalk-ai/ghz v0.1.23
 	github.com/goccy/go-json v0.10.3
+	github.com/google/uuid v1.6.0
 	github.com/jhump/protoreflect v1.17.0
 	github.com/samber/lo v1.47.0
 	github.com/schollz/progressbar/v3 v3.16.0
@@ -14,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
+	google.golang.org/grpc v1.67.0
 	google.golang.org/protobuf v1.34.2
 )
 
@@ -48,7 +50,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -97,7 +98,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240924160255-9d4c2d233b61 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61 // indirect
-	google.golang.org/grpc v1.67.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chalk-ai/chalk-go v0.17.1 h1:IKvEsSUO3haD2RsYM/NX9d349AalR+3UHNmO3P3pTmw=
 github.com/chalk-ai/chalk-go v0.17.1/go.mod h1:wr4z7NQP8Hg2xuMGvLMY/Clf6JCfvShb/US0esGg1LM=
-github.com/chalk-ai/ghz v0.1.22 h1:MZ6U4JWhEbYIWufNDOud4zIAW/5C0Kla5u4X1i5eADI=
-github.com/chalk-ai/ghz v0.1.22/go.mod h1:N28yx6mY35alo2DRgjUl08VhUlvgckdaPZFVbIx6DlY=
+github.com/chalk-ai/ghz v0.1.23 h1:ctJwwqItXmyQJXf0xHq5MfGtBRmfnlSAjM/rFSvCYkQ=
+github.com/chalk-ai/ghz v0.1.23/go.mod h1:N28yx6mY35alo2DRgjUl08VhUlvgckdaPZFVbIx6DlY=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
 github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8ETbOasdwEV+avkR75ZzsVV9WI=


### PR DESCRIPTION
Corresponding update to make sure this flag is utilized. Since we are making this an optional calculation as opposed to an optional display in the chart, it needs to be passed as a header to all queries rather than the display to the chart calculation.

PR that needs to be merged first: https://github.com/chalk-ai/ghz/pull/26